### PR TITLE
UUID tool is warning free

### DIFF
--- a/uuid/src/main.rs
+++ b/uuid/src/main.rs
@@ -1,23 +1,20 @@
 extern crate uuid;
 
-use std::io;
-use std::io::Write;
+use std::fs;
 use std::path::Path;
 use uuid::Uuid;
-use std::fs;
-use std::fs::File;
 
 fn main() {
-    let mut my_uuid = Uuid::new_v4();
+    let my_uuid = Uuid::new_v4();
     println!("{}", my_uuid);
     write_to_txt(my_uuid);
 }
 
-fn write_to_txt(uuid :Uuid) -> io::Result<()> {
+fn write_to_txt(uuid :Uuid) {
     let result = does_file_exist();
 
     if result == false {
-        File::create("./uuid");
+        fs::File::create("./uuid").expect("Unable to create file!");
         println!("File created!");
     } else {
         println!("File already created!");
@@ -28,7 +25,6 @@ fn write_to_txt(uuid :Uuid) -> io::Result<()> {
     fs::write("./uuid", uuid_string).expect("Unable to write file");
 
     println!("File written!");
-    Ok(())
 }
 
 fn does_file_exist() -> bool {


### PR DESCRIPTION
New feature incoming:
The UUID generation tool is now warning free! When you compile the UUID generation source, the output should no longer have errors.